### PR TITLE
:bug: Use bounds_changed event instead of resize

### DIFF
--- a/src/CanvasLayer.js
+++ b/src/CanvasLayer.js
@@ -382,7 +382,7 @@ CanvasLayer.prototype.onAdd = function() {
   this.setPane_();
 
   this.resizeListener_ = google.maps.event.addListener(this.getMap(),
-      'resize', this.resizeFunction_);
+      'bounds_changed', this.resizeFunction_);
   this.centerListener_ = google.maps.event.addListener(this.getMap(),
       'center_changed', this.repositionFunction_);
 


### PR DESCRIPTION
I had to change the `resize` event to the `bounds-changed` to get resize to work.

https://github.com/brendankenny/CanvasLayer/blob/975880e3942c7046090f3e7acbe3cb9f3255c113/src/CanvasLayer.js#L384-385

https://developers.google.com/maps/documentation/javascript/3.exp/reference#Map

> `bounds_changed`: This event is fired when the viewport bounds have changed.
> 
> `resize`: Developers should trigger this event on the map when the div changes size: google.maps.event.trigger(map, 'resize')
